### PR TITLE
Allow modfile to be used to specify location

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,6 +55,12 @@ func main() {
 		}
 		return
 	}
+	if *modfile == "" {
+		*modfile = path.Join(*moddir, "output.json")
+	}
+
+	basename := path.Base(*modfile)
+	outputOps := file.NewJSONOps(path.Dir(*modfile))
 
 	m := &mod.Mod{
 		Lua:         lua,
@@ -62,14 +68,14 @@ func main() {
 		Objs:        objs,
 		Objdirs:     objdir,
 		RootRead:    rootops,
-		RootWrite:   rootops,
+		RootWrite:   outputOps,
 	}
 	err := m.GenerateFromConfig()
 	if err != nil {
 		fmt.Printf("generateMod(<config>) : %v\n", err)
 		return
 	}
-	err = m.Print()
+	err = m.Print(basename)
 	if err != nil {
 		log.Fatalf("printMod(...) : %v", err)
 	}

--- a/mod/generate.go
+++ b/mod/generate.go
@@ -120,8 +120,8 @@ func (m *Mod) generate(raw types.J) error {
 }
 
 // Print outputs internal representation of mod to json file with indents
-func (m *Mod) Print() error {
-	return m.RootWrite.WriteObj(m.Data, "output.json")
+func (m *Mod) Print(basename string) error {
+	return m.RootWrite.WriteObj(m.Data, basename)
 }
 
 func tryPut(d *types.J, from, to string, fun func(string) (interface{}, error)) {

--- a/mod/generate_test.go
+++ b/mod/generate_test.go
@@ -81,7 +81,7 @@ func TestGenerate(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error reading config %v", err)
 			}
-			err = m.Print()
+			err = m.Print("output.json")
 			if err != nil {
 				t.Fatalf("Error printing config %v", err)
 			}

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -78,7 +78,7 @@ func TestAllReverseThenBuild(t *testing.T) {
 			if err != nil {
 				t.Fatalf("generateMod(<config>) : %v\n", err)
 			}
-			err = m.Print()
+			err = m.Print("output.json")
 			if err != nil {
 				t.Fatalf("printMod(...) : %v", err)
 			}


### PR DESCRIPTION
When generating previously the file always was put in moddir/output.json. Now it is configurable, but still defaults to the above location.