### PR TITLE
Allow downloadable content to be compiled & reversed

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,37 @@ $moddir = directory to read from
 TTSModManager.exe --moddir="C:\Users\USER\Documents\Projects\MyProject"
 ```
 
+## Working with downloadable content
+TTS allows you to download content into a active game. This content must be a
+json file in the form of a single object. In order to accomodate storing these
+downloadable json files, TTSModManager can assemble and reverse these files.
+
+### Generating a downloadable file
+
+In this example foo.json the root of a partial mod object you'd like to
+represent as a downloadable json.
+
+```
+TTSModManager.exe --moddir="C:\Users\USER\Documents\Projects\MyProject"
+--objin="C:\Users\USER\Documents\Projects\MyProject\downloadable\content\foo.json"
+--objout="C:\Users\USER\Documents\Projects\MyProject\to_be_downloaded.json"
+```
+
+### Reversing a downloadable file
+
+This process assumes you already have your file you are used to downloading, and
+want to decompose it into sub-objects and luascript etc.
+
+Please note that **objout** is a directory and the trailing slash is needed.
+
+```
+TTSModManager.exe --moddir="C:\Users\USER\Documents\Projects\MyProject"
+--reverse
+--objin="C:\Users\USER\Documents\Projects\MyProject\ready_to_download.json"
+--objout="C:\Users\USER\Documents\Projects\MyProject\downloadable\content\"
+```
+
+
 ## Running a local copy
 
 If you are developing a feature and would like to run the tool, use this instead of `TTSModManager.exe`

--- a/bundler/luabundler.go
+++ b/bundler/luabundler.go
@@ -181,7 +181,14 @@ func Bundle(rawlua string, l file.TextReader) (string, error) {
 
 	bundlestr := metaprefix + "\n"
 
-	for k, v := range reqs {
+	sortedReqKeys := []string{}
+	for k := range reqs {
+		sortedReqKeys = append(sortedReqKeys, k)
+	}
+	sort.Strings(sortedReqKeys)
+
+	for _, k := range sortedReqKeys {
+		v := reqs[k]
 		bundlestr += strings.Replace(funcprefix, funcprefixReplace, k, 1) + "\n"
 		bundlestr += v + "\n"
 		bundlestr += funcsuffix + "\n"

--- a/file/dirops.go
+++ b/file/dirops.go
@@ -56,7 +56,7 @@ func (d *DirOps) ListFilesAndFolders(relpath string) ([]string, []string, error)
 	p := path.Join(d.base, relpath)
 	files, err := ioutil.ReadDir(p)
 	if err != nil {
-		return nil, nil, fmt.Errorf("ioutil.ReadDir(%s) : %v", p, err)
+		return nil, nil, fmt.Errorf("ioutil.ReadDir(%s + %s) : %v", d.base, relpath, err)
 	}
 	fnames := make([]string, 0)
 	folnames := make([]string, 0)

--- a/main.go
+++ b/main.go
@@ -22,7 +22,7 @@ var (
 	objfile      = flag.String("objfile", "", "if building only object state list, output to this filename")
 )
 
-const (
+var (
 	luasrcSubdir   = "src"
 	xmlsrcSubdir   = "xml"
 	modsettingsDir = "modsettings"
@@ -31,6 +31,12 @@ const (
 
 func main() {
 	flag.Parse()
+
+	// only create an object state list, not an entire mod
+	if *objstatesdir != "" {
+		objectsSubdir = *objstatesdir
+		*modfile = *objfile
+	}
 
 	lua := file.NewTextOpsMulti(
 		[]string{path.Join(*moddir, luasrcSubdir), path.Join(*moddir, objectsSubdir)},
@@ -47,16 +53,6 @@ func main() {
 	objdir := file.NewDirOps(path.Join(*moddir, objectsSubdir))
 	rootops := file.NewJSONOps(*moddir)
 
-	// only create an object state list, not an entire mod
-	if *objstatesdir != "" {
-		lua = file.NewLuaOpsMulti(
-			[]string{path.Join(*moddir, textSubdir), path.Join(*moddir, *objstatesdir)},
-			path.Join(*moddir, *objstatesdir),
-		)
-		objs = file.NewJSONOps(path.Join(*moddir, *objstatesdir))
-		objdir = file.NewDirOps(path.Join(*moddir, *objstatesdir))
-		*modfile = *objfile
-	}
 	basename := path.Base(*modfile)
 	outputOps := file.NewJSONOps(path.Dir(*modfile))
 

--- a/main.go
+++ b/main.go
@@ -47,6 +47,19 @@ func main() {
 	objdir := file.NewDirOps(path.Join(*moddir, objectsSubdir))
 	rootops := file.NewJSONOps(*moddir)
 
+	// only create an object state list, not an entire mod
+	if *objstatesdir != "" {
+		lua = file.NewLuaOpsMulti(
+			[]string{path.Join(*moddir, textSubdir), path.Join(*moddir, *objstatesdir)},
+			path.Join(*moddir, *objstatesdir),
+		)
+		objs = file.NewJSONOps(path.Join(*moddir, *objstatesdir))
+		objdir = file.NewDirOps(path.Join(*moddir, *objstatesdir))
+		*modfile = *objfile
+	}
+	basename := path.Base(*modfile)
+	outputOps := file.NewJSONOps(path.Dir(*modfile))
+
 	if *rev {
 		raw, err := prepForReverse(*moddir, *modfile)
 		if err != nil {
@@ -59,6 +72,7 @@ func main() {
 			ObjWriter:         objs,
 			ObjDirCreeator:    objdir,
 			RootWrite:         rootops,
+			OnlyObjState:      (*objstatesdir != ""),
 		}
 		if *writeToSrc {
 			r.LuaSrcWriter = luaSrc
@@ -74,19 +88,6 @@ func main() {
 		*modfile = path.Join(*moddir, "output.json")
 	}
 
-	basename := path.Base(*modfile)
-	outputOps := file.NewJSONOps(path.Dir(*modfile))
-	// only create an object state list, not an entire mod
-	if *objstatesdir != "" {
-		lua = file.NewLuaOpsMulti(
-			[]string{path.Join(*moddir, textSubdir), path.Join(*moddir, *objstatesdir)},
-			path.Join(*moddir, *objstatesdir),
-		)
-		objs = file.NewJSONOps(path.Join(*moddir, *objstatesdir))
-		objdir = file.NewDirOps(path.Join(*moddir, *objstatesdir))
-		outputOps = file.NewJSONOps(path.Dir(path.Join(*moddir, *objfile)))
-		basename = path.Base(*objfile)
-	}
 	m := &mod.Mod{
 
 		Lua:           lua,

--- a/mod/generate.go
+++ b/mod/generate.go
@@ -39,7 +39,6 @@ type Mod struct {
 	Objdirs     file.DirExplorer
 
 	OnlyObjStates bool
-	objstates     []map[string]interface{}
 }
 
 // GenerateFromConfig uses RootRead for reading entire mod config
@@ -59,10 +58,12 @@ func (m *Mod) generateOnlyObjStates() error {
 	if err != nil {
 		return fmt.Errorf("objects.ParseAllObjectStates(%s) : %v", "", err)
 	}
-	if allObjs == nil {
-		allObjs = []map[string]interface{}{}
+	if len(allObjs) != 1 {
+		return fmt.Errorf("ParseAllObjectStates() in OnlyObjStates mode expects a single root object")
 	}
-	m.objstates = allObjs
+	for _, k := range allObjs {
+		m.Data = k
+	}
 	return nil
 }
 
@@ -145,9 +146,6 @@ func (m *Mod) generate(raw types.J) error {
 
 // Print outputs internal representation of mod to json file with indents
 func (m *Mod) Print(basename string) error {
-	if m.OnlyObjStates {
-		return m.RootWrite.WriteObjArray(m.objstates, basename)
-	}
 	return m.RootWrite.WriteObj(m.Data, basename)
 }
 

--- a/mod/generate.go
+++ b/mod/generate.go
@@ -7,6 +7,7 @@ import (
 	"ModCreator/types"
 	"fmt"
 	"log"
+	"strings"
 	"time"
 )
 
@@ -38,12 +39,13 @@ type Mod struct {
 	Objs        file.JSONReader
 	Objdirs     file.DirExplorer
 
-	OnlyObjStates bool
+	// If not-empty: this holds the root filename for the object state json object
+	OnlyObjStates string
 }
 
 // GenerateFromConfig uses RootRead for reading entire mod config
 func (m *Mod) GenerateFromConfig() error {
-	if m.OnlyObjStates {
+	if m.OnlyObjStates != "" {
 		return m.generateOnlyObjStates()
 	}
 	raw, err := m.RootRead.ReadObj("config.json")
@@ -54,9 +56,10 @@ func (m *Mod) GenerateFromConfig() error {
 }
 
 func (m *Mod) generateOnlyObjStates() error {
-	allObjs, err := objects.ParseAllObjectStates(m.Lua, m.XML, m.Objs, m.Objdirs, []string{objects.OnlyOneOrder})
+	nameAndGuid := strings.TrimSuffix(m.OnlyObjStates, ".json")
+	allObjs, err := objects.ParseAllObjectStates(m.Lua, m.XML, m.Objs, m.Objdirs, []string{nameAndGuid})
 	if err != nil {
-		return fmt.Errorf("objects.ParseAllObjectStates(%s) : %v", "", err)
+		return fmt.Errorf("objects.ParseAllObjectStates(%s) : %v", m.OnlyObjStates, err)
 	}
 	if len(allObjs) != 1 {
 		return fmt.Errorf("ParseAllObjectStates() in OnlyObjStates mode expects a single root object")

--- a/mod/reverse.go
+++ b/mod/reverse.go
@@ -21,7 +21,8 @@ type Reverser struct {
 	ObjDirCreeator    file.DirCreator
 	RootWrite         file.JSONWriter
 
-	OnlyObjState bool
+	// If not empty: holds the entire filename (C:...) of the json to read
+	OnlyObjState string
 }
 
 func (r *Reverser) writeOnlyObjStates(raw map[string]interface{}) error {
@@ -42,7 +43,7 @@ func (r *Reverser) writeOnlyObjStates(raw map[string]interface{}) error {
 // Write executes the main purpose of the reverse library:
 // to take a json object and create a file struture which mimics it.
 func (r *Reverser) Write(raw map[string]interface{}) error {
-	if r.OnlyObjState {
+	if r.OnlyObjState != "" {
 		return r.writeOnlyObjStates(raw)
 	}
 	pathExt := "_path"

--- a/mod/reverse.go
+++ b/mod/reverse.go
@@ -20,11 +20,31 @@ type Reverser struct {
 	ObjWriter         file.JSONWriter
 	ObjDirCreeator    file.DirCreator
 	RootWrite         file.JSONWriter
+
+	OnlyObjState bool
+}
+
+func (r *Reverser) writeOnlyObjStates(raw map[string]interface{}) error {
+	printer := &objects.Printer{
+		Lua:    r.LuaWriter,
+		LuaSrc: r.LuaSrcWriter,
+		J:      r.ObjWriter,
+		Dir:    r.ObjDirCreeator,
+	}
+	arraywrap := []map[string]interface{}{raw}
+	_, err := printer.PrintObjectStates("", arraywrap)
+	if err != nil {
+		return fmt.Errorf("PrintObjectStates('', <%v objects>): %v", len(arraywrap), err)
+	}
+	return nil
 }
 
 // Write executes the main purpose of the reverse library:
 // to take a json object and create a file struture which mimics it.
 func (r *Reverser) Write(raw map[string]interface{}) error {
+	if r.OnlyObjState {
+		return r.writeOnlyObjStates(raw)
+	}
 	pathExt := "_path"
 
 	for _, strKey := range ExpectedStr {

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -11,8 +11,6 @@ import (
 	"fmt"
 )
 
-const OnlyOneOrder = "TTS_MOD_MANAGER_ONLY_ONE_OBJ"
-
 type objConfig struct {
 	guid               string
 	data               J
@@ -295,17 +293,8 @@ func (d *db) print(l file.TextReader, x file.TextReader, order []string) (ObjArr
 		return nil, fmt.Errorf("expected order (%v) and db.root (%v) to have same length", len(order), len(d.root))
 	}
 	for _, nextGUID := range order {
-		if nextGUID == OnlyOneOrder {
-			// assert that the length is one, then set nextGUID to whatever guid root has
-			if len(d.root) != 1 {
-				return nil, fmt.Errorf("Only use the '%s' order if you require only one root object", OnlyOneOrder)
-			}
-			for k := range d.root {
-				nextGUID = k
-			}
-		}
 		if _, ok := d.root[nextGUID]; !ok {
-			return nil, fmt.Errorf("order expected %s, not found in db", nextGUID)
+			return nil, fmt.Errorf("order expected %s, not found in db <%v>", nextGUID, d.root)
 		}
 		printed, err := d.root[nextGUID].print(l, x)
 		if err != nil {

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 )
 
+const OnlyOneOrder = "TTS_MOD_MANAGER_ONLY_ONE_OBJ"
+
 type objConfig struct {
 	guid               string
 	data               J
@@ -293,6 +295,15 @@ func (d *db) print(l file.TextReader, x file.TextReader, order []string) (ObjArr
 		return nil, fmt.Errorf("expected order (%v) and db.root (%v) to have same length", len(order), len(d.root))
 	}
 	for _, nextGUID := range order {
+		if nextGUID == OnlyOneOrder {
+			// assert that the length is one, then set nextGUID to whatever guid root has
+			if len(d.root) != 1 {
+				return nil, fmt.Errorf("Only use the '%s' order if you require only one root object", OnlyOneOrder)
+			}
+			for k := range d.root {
+				nextGUID = k
+			}
+		}
 		if _, ok := d.root[nextGUID]; !ok {
 			return nil, fmt.Errorf("order expected %s, not found in db", nextGUID)
 		}


### PR DESCRIPTION
This allows for -objin and -objout to be used to construct and deconstruct object files which are particularly useful because TTS offers ability to download objects into a game instance