### PR TITLE
Bugfix: return value correction for path.Base()

### DIFF
--- a/main.go
+++ b/main.go
@@ -101,6 +101,12 @@ func main() {
 		*modfile = path.Join(*moddir, "output.json")
 	}
 
+	// setting this to empty instead of default return value (".") if not found
+	OnlyObjStates := path.Base(*objin)
+	if OnlyObjStates == "." {
+		OnlyObjStates = ""
+	}
+
 	m := &mod.Mod{
 		Lua:           lua,
 		XML:           xml,
@@ -109,7 +115,7 @@ func main() {
 		Objdirs:       objdir,
 		RootRead:      rootops,
 		RootWrite:     outputOps,
-		OnlyObjStates: path.Base(*objin),
+		OnlyObjStates: OnlyObjStates,
 	}
 	err := m.GenerateFromConfig()
 	if err != nil {

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -55,13 +55,6 @@ func (o *objConfig) parseFromJSON(data map[string]interface{}) error {
 	if !ok {
 		return fmt.Errorf("object (%v) doesn't have a string GUID (%s)", dguid, o.data["GUID"])
 	}
-	_, ok = o.data["XmlUI_path"]
-	if !ok {
-		_, ok = o.data["XmlUI"]
-		if !ok {
-			o.data["XmlUI"] = ""
-		}
-	}
 	o.guid = guid
 	o.subObj = []*objConfig{}
 	o.subObjOrder = []string{}


### PR DESCRIPTION
This corrects the return value from `path.Base()`, since it is assumed to be "" in `generate.go`.

Relevant code that was falsely firing on "regular bundling / unbundling":
https://github.com/argonui/TTSModManager/blob/main/mod/generate.go#L42-L50

closes https://github.com/argonui/TTSModManager/issues/63