### PR TITLE
Changes path to fliepath package for OS compatibility

### DIFF
--- a/bundler/xmlbundler.go
+++ b/bundler/xmlbundler.go
@@ -59,8 +59,7 @@ func indentString(s string, indent string) string {
 	return strings.Join(final, "\n")
 }
 
-// UnbundleAllXML converts a bundled xml file to mapping of filenames to
-// contents
+// UnbundleAllXML converts a bundled xml file to mapping of filenames to contents
 func UnbundleAllXML(rawxml string) (map[string]string, error) {
 	type inc struct {
 		name  string
@@ -83,7 +82,7 @@ func UnbundleAllXML(rawxml string) (map[string]string, error) {
 			indent := string(submatches[1])
 			indentedvals := xmlarray[stack[0].start+1 : ln]
 
-			// do not let mods specify relative paths.
+			// do not let mods specify relative paths
 			storedName := strings.Replace(stack[0].name, "../", "", -1)
 
 			store[storedName] = unindentAndJoin(indentedvals, indent)
@@ -95,7 +94,7 @@ func UnbundleAllXML(rawxml string) (map[string]string, error) {
 			ln = stack[0].start
 			stack = stack[1:]
 		} else {
-			stack = append([]inc{inc{name: key, start: ln}}, stack...)
+			stack = append([]inc{{name: key, start: ln}}, stack...)
 		}
 	}
 	if len(stack) != 0 {

--- a/mod/generate.go
+++ b/mod/generate.go
@@ -29,14 +29,14 @@ var (
 // Mod is used as the accurate representation of what gets printed when
 // module creation is done
 type Mod struct {
-	Data 					types.J
-	RootRead    	file.JSONReader
-	RootWrite   	file.JSONWriter
-	Lua         	file.TextReader
-	XML         	file.TextReader
-	Modsettings 	file.JSONReader
-	Objs        	file.JSONReader
-	Objdirs     	file.DirExplorer
+	Data          types.J
+	RootRead      file.JSONReader
+	RootWrite     file.JSONWriter
+	Lua           file.TextReader
+	XML           file.TextReader
+	Modsettings   file.JSONReader
+	Objs          file.JSONReader
+	Objdirs       file.DirExplorer
 
 	// If not-empty: this holds the root filename for the object state json object
 	OnlyObjStates string

--- a/mod/generate.go
+++ b/mod/generate.go
@@ -29,15 +29,14 @@ var (
 // Mod is used as the accurate representation of what gets printed when
 // module creation is done
 type Mod struct {
-	Data types.J
-
-	RootRead    file.JSONReader
-	RootWrite   file.JSONWriter
-	Lua         file.TextReader
-	XML         file.TextReader
-	Modsettings file.JSONReader
-	Objs        file.JSONReader
-	Objdirs     file.DirExplorer
+	Data 					types.J
+	RootRead    	file.JSONReader
+	RootWrite   	file.JSONWriter
+	Lua         	file.TextReader
+	XML         	file.TextReader
+	Modsettings 	file.JSONReader
+	Objs        	file.JSONReader
+	Objdirs     	file.DirExplorer
 
 	// If not-empty: this holds the root filename for the object state json object
 	OnlyObjStates string

--- a/mod/reverse.go
+++ b/mod/reverse.go
@@ -5,9 +5,7 @@ import (
 	"ModCreator/handler"
 	"ModCreator/objects"
 	"ModCreator/types"
-	"encoding/json"
 	"fmt"
-	"io/ioutil"
 )
 
 // Reverser holds interfaces and configs for the reversing process
@@ -18,11 +16,11 @@ type Reverser struct {
 	XMLWriter         file.TextWriter
 	XMLSrcWriter      file.TextWriter
 	ObjWriter         file.JSONWriter
-	ObjDirCreeator    file.DirCreator
+	ObjDirCreator     file.DirCreator
 	RootWrite         file.JSONWriter
 
 	// If not empty: holds the entire filename (C:...) of the json to read
-	OnlyObjState string
+	OnlyObjState      string
 }
 
 func (r *Reverser) writeOnlyObjStates(raw map[string]interface{}) error {
@@ -30,7 +28,7 @@ func (r *Reverser) writeOnlyObjStates(raw map[string]interface{}) error {
 		Lua:    r.LuaWriter,
 		LuaSrc: r.LuaSrcWriter,
 		J:      r.ObjWriter,
-		Dir:    r.ObjDirCreeator,
+		Dir:    r.ObjDirCreator,
 	}
 	arraywrap := []map[string]interface{}{raw}
 	_, err := printer.PrintObjectStates("", arraywrap)
@@ -58,7 +56,7 @@ func (r *Reverser) Write(raw map[string]interface{}) error {
 			return fmt.Errorf("expected string value in key %s, got %v", strKey, rawVal)
 		}
 		if strKey == "LuaScript" || strKey == "XmlUI" {
-			// let the LuaHAndler handle the complicated case
+			// let the LuaHandler handle the complicated case
 			continue
 		}
 		ext := ".luascriptstate"
@@ -168,7 +166,7 @@ func (r *Reverser) Write(raw map[string]interface{}) error {
 			XML:    r.XMLWriter,
 			XMLSrc: r.XMLSrcWriter,
 			J:      r.ObjWriter,
-			Dir:    r.ObjDirCreeator,
+			Dir:    r.ObjDirCreator,
 		}
 		order, err := printer.PrintObjectStates("", objStates)
 		if err != nil {
@@ -183,18 +181,10 @@ func (r *Reverser) Write(raw map[string]interface{}) error {
 	delete(raw, DateKey)
 	delete(raw, EpochKey)
 
-	// write all that's Left
+	// write all that's left
 	err = r.RootWrite.WriteObj(raw, "config.json")
 	if err != nil {
 		return fmt.Errorf("WriteObj(<obj>, %s) : %v", "config.json", err)
 	}
 	return nil
-}
-
-func writeJSON(raw map[string]interface{}, filename string) error {
-	b, err := json.MarshalIndent(raw, "", "  ")
-	if err != nil {
-		return fmt.Errorf("json.MarshalIndent() : %v", err)
-	}
-	return ioutil.WriteFile(filename, b, 0644)
 }

--- a/mod/reverse_test.go
+++ b/mod/reverse_test.go
@@ -249,7 +249,7 @@ func TestReverse(t *testing.T) {
 				LuaSrcWriter:      srcTexts,
 				XMLWriter:         srcTexts,
 				ObjWriter:         objsAndLua,
-				ObjDirCreeator:    objsAndLua,
+				ObjDirCreator:     objsAndLua,
 				RootWrite:         finalOutput,
 			}
 			err := r.Write(tc.input)

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -56,7 +56,7 @@ func TestAllReverseThenBuild(t *testing.T) {
 				XMLSrcWriter:      objsAndLua,
 				LuaSrcWriter:      objsAndLua,
 				ObjWriter:         objsAndLua,
-				ObjDirCreeator:    objsAndLua,
+				ObjDirCreator:     objsAndLua,
 				RootWrite:         finalOutput,
 			}
 			err = r.Write(j)


### PR DESCRIPTION
This change makes sure that parameters can use either "/" or "\".
Additionally, corrects some typos and inconsistenties in comments.