### PR TITLE
Changed path for folder creation when unbundling a single object

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 	// handling for saved objects instead of a full savegame
 	if *objin != "" {
 		objs = file.NewJSONOps(filepath.Dir(*objin))
-		objdir = file.NewDirOps(filepath.Dir(*objin))
+		objdir = file.NewDirOps(filepath.Dir(*objout))
 		lua = file.NewTextOpsMulti(
 			[]string{filepath.Join(*moddir, luasrcSubdir), filepath.Dir(*objin)},
 			filepath.Dir(*objout),


### PR DESCRIPTION
Without this change, there will be empty folders created in the folder of the `objin` file. These folders mimic the actual folder structure for the real output, but are fully empty.