### PR TITLE
Replaced the deprecated ioutil package

### DIFF
--- a/file/dirops.go
+++ b/file/dirops.go
@@ -2,10 +2,10 @@ package file
 
 import (
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path"
+	"path/filepath"
 )
 
 // DirCreator abstracts folder creation
@@ -53,19 +53,19 @@ func (d *DirOps) CreateDir(relpath, suggestion string) (string, error) {
 
 // ListFilesAndFolders allows for file exploration. returns relateive file or folder names
 func (d *DirOps) ListFilesAndFolders(relpath string) ([]string, []string, error) {
-	p := path.Join(d.base, relpath)
-	files, err := ioutil.ReadDir(p)
+	p := filepath.Join(d.base, relpath)
+	entries, err := os.ReadDir(p)
 	if err != nil {
-		return nil, nil, fmt.Errorf("ioutil.ReadDir(%s + %s) : %v", d.base, relpath, err)
+		return nil, nil, fmt.Errorf("os.ReadDir(%s + %s) : %v", d.base, relpath, err)
 	}
-	fnames := make([]string, 0)
-	folnames := make([]string, 0)
-	for _, file := range files {
-		if file.IsDir() {
-			folnames = append(folnames, path.Join(relpath, file.Name()))
-			continue
+
+	var fnames, folnames []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			folnames = append(folnames, filepath.Join(relpath, entry.Name()))
+		} else {
+			fnames = append(fnames, filepath.Join(relpath, entry.Name()))
 		}
-		fnames = append(fnames, path.Join(relpath, file.Name()))
 	}
 	return fnames, folnames, nil
 }

--- a/file/jsonops.go
+++ b/file/jsonops.go
@@ -3,7 +3,7 @@ package file
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 )
@@ -62,7 +62,7 @@ func (j *JSONOps) pullRawFile(filename string) ([]byte, error) {
 	}
 	defer jFile.Close()
 
-	return ioutil.ReadAll(jFile)
+	return io.ReadAll(jFile)
 }
 
 // WriteObj writes a serialized json object to a file.
@@ -77,7 +77,7 @@ func (j *JSONOps) WriteObj(m map[string]interface{}, filename string) error {
 	if err != nil && !os.IsExist(err) {
 		return fmt.Errorf("MkdirAll(%s): %v", path.Dir(p), err)
 	}
-	return ioutil.WriteFile(p, b, 0644)
+	return os.WriteFile(p, b, 0644)
 }
 
 // WriteObjArray writes an array of serialized json objects to a file.
@@ -92,7 +92,7 @@ func (j *JSONOps) WriteObjArray(m []map[string]interface{}, filename string) err
 	if err != nil && !os.IsExist(err) {
 		return fmt.Errorf("MkdirAll(%s): %v", path.Dir(p), err)
 	}
-	return ioutil.WriteFile(p, b, 0644)
+	return os.WriteFile(p, b, 0644)
 }
 
 // ReadRawFile allows for anyone who needs to to read json without objects.
@@ -103,7 +103,7 @@ func ReadRawFile(filename string) (map[string]interface{}, error) {
 	}
 	defer jFile.Close()
 
-	b, err := ioutil.ReadAll(jFile)
+	b, err := io.ReadAll(jFile)
 	if err != nil {
 		return nil, err
 	}

--- a/file/textops.go
+++ b/file/textops.go
@@ -2,7 +2,7 @@ package file
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 )
@@ -42,7 +42,7 @@ func NewTextOpsMulti(readDirs []string, writeDir string) *TextOps {
 			}
 			defer sFile.Close()
 
-			b, err := ioutil.ReadAll(sFile)
+			b, err := io.ReadAll(sFile)
 			if err != nil {
 				return nil, fmt.Errorf("ReadAll(%s): %v", s, err)
 			}

--- a/main.go
+++ b/main.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -155,7 +155,7 @@ func prepForReverse(cPath, modfile string) (types.J, error) {
 
 	defer mFile.Close()
 
-	b, err := ioutil.ReadAll(mFile)
+	b, err := io.ReadAll(mFile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Since Go 1.16 ioutil has been deprecated (https://github.com/golang/go/issues/40025).
This PR updates the code that uses ioutil.