### PR TITLE
Reverted path for folder creation

### DIFF
--- a/main.go
+++ b/main.go
@@ -57,7 +57,7 @@ func main() {
 	// handling for saved objects instead of a full savegame
 	if *objin != "" {
 		objs = file.NewJSONOps(filepath.Dir(*objin))
-		objdir = file.NewDirOps(filepath.Dir(*objout))
+		objdir = file.NewDirOps(filepath.Dir(*objin))
 		lua = file.NewTextOpsMulti(
 			[]string{filepath.Join(*moddir, luasrcSubdir), filepath.Dir(*objin)},
 			filepath.Dir(*objout),


### PR DESCRIPTION
This reverts https://github.com/argonui/TTSModManager/pull/74.

The bundling of loadable objects fails without this since it's looking in the wrong folder for root objects.