### PR TITLE
VS Code: Disable Lua diagnostics

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "Lua.diagnostics.enable": false
+}


### PR DESCRIPTION
This will disable Lua diagnostics for this project since the test files trigger a lot of warnings.