### PR TITLE
Allow more characters in file names

### DIFF
--- a/objects/objects.go
+++ b/objects/objects.go
@@ -322,8 +322,8 @@ func (o *objConfig) printToFile(filepath string, p *Printer) error {
 }
 
 func (o *objConfig) getAGoodFileName() string {
-	// only let alphanumberic, _, -, be put into names
-	reg := regexp.MustCompile("[^a-zA-Z0-9_-]+")
+	// This allows any letter or number from any language, plus _ and -
+	reg := regexp.MustCompile(`[^\p{L}\p{N}_-]+`)
 
 	keyname, err := o.tryGetNonEmptyStr("Nickname")
 	if err != nil {

--- a/objects/objects.go
+++ b/objects/objects.go
@@ -322,8 +322,8 @@ func (o *objConfig) printToFile(filepath string, p *Printer) error {
 }
 
 func (o *objConfig) getAGoodFileName() string {
-	// This allows any letter or number from any language, plus _ and -
-	reg := regexp.MustCompile(`[^\p{L}\p{N}_-]+`)
+	// This allows any letter or number from any language, plus _, -, and !
+	reg := regexp.MustCompile(`[^\p{L}\p{N}_!-]+`)
 
 	keyname, err := o.tryGetNonEmptyStr("Nickname")
 	if err != nil {

--- a/objects/objects_test.go
+++ b/objects/objects_test.go
@@ -404,7 +404,14 @@ func TestName(t *testing.T) {
 				"Name":     "Card",
 			},
 			guid: "010509",
-			want: "OccultInvocation.010509",
+			want: "OccultInvocation!!!!.010509",
+		}, {
+				data: types.J{
+				"Nickname": "Verschwörung der Äxte!",
+				"Name":     "Card",
+			},
+			guid: "010511",
+			want: "VerschwörungderÄxte!.010511",
 		}, {
 			data: types.J{
 				"Name": "Card",


### PR DESCRIPTION
With the creation of localized card packages, I had the issue that some languages (like cyrillic) would not be able to generate any filenames since all characters would be marked as "illegal" by the Mod Manager.
This expands the range of allowed characters to better support non-english languages.