### PR TITLE
New feature: clear objects folder before reversing

### DIFF
--- a/file/dirops.go
+++ b/file/dirops.go
@@ -11,6 +11,7 @@ import (
 // DirCreator abstracts folder creation
 type DirCreator interface {
 	CreateDir(relpath string, suggestion string) (string, error)
+	Clear() error
 }
 
 // DirExplorer allows files and folders to be enumerated
@@ -49,6 +50,23 @@ func (d *DirOps) CreateDir(relpath, suggestion string) (string, error) {
 		return "", fmt.Errorf("could not find sutible name for sub directory based on suggestion %s; %v", suggestion, err)
 	}
 	return dirname, nil
+}
+
+// Clear removes all contents from the base directory and recreates it.
+func (d *DirOps) Clear() error {
+	log.Printf("Clearing directory: %s", d.base)
+
+	// Remove the directory and all its contents
+	if err := os.RemoveAll(d.base); err != nil {
+		return fmt.Errorf("error clearing directory %s: %w", d.base, err)
+	}
+
+	// Recreate the empty directory
+	if err := os.MkdirAll(d.base, 0755); err != nil {
+		return fmt.Errorf("error recreating directory %s: %w", d.base, err)
+	}
+
+	return nil
 }
 
 // ListFilesAndFolders allows for file exploration. returns relateive file or folder names

--- a/main.go
+++ b/main.go
@@ -92,21 +92,22 @@ func main() {
 		if *objin != "" {
 			*modfile = *objin
 			objs = file.NewJSONOps(filepath.Dir(*objout))
+		} else {
+			// clear the objects directory to avoid orphaned files (by removing and recreating)
+			objectsPath := filepath.Join(*moddir, objectsSubdir)
+
+			if err := os.RemoveAll(objectsPath); err != nil {
+				log.Fatalf("Error clearing directory %s: %v", objectsPath, err)
+			}
+
+			if err := os.MkdirAll(objectsPath, 0755); err != nil {
+				log.Fatalf("Error recreating directory %s: %v", objectsPath, err)
+			}
 		}
+	
 		raw, err := prepForReverse(*moddir, *modfile)
 		if err != nil {
 			log.Fatalf("prepForReverse (%s) failed : %v", *modfile, err)
-		}
-
-		// clear the objects directory to avoid orphaned files (by removing and recreating)
-		objectsPath := filepath.Join(*moddir, objectsSubdir)
-
-		if err := os.RemoveAll(objectsPath); err != nil {
-			log.Fatalf("Error clearing directory %s: %v", objectsPath, err)
-		}
-
-		if err := os.MkdirAll(objectsPath, 0755); err != nil {
-			log.Fatalf("Error recreating directory %s: %v", objectsPath, err)
 		}
 
 		r := mod.Reverser{

--- a/main.go
+++ b/main.go
@@ -98,6 +98,17 @@ func main() {
 			log.Fatalf("prepForReverse (%s) failed : %v", *modfile, err)
 		}
 
+		// clear the objects directory to avoid orphaned files (by removing and recreating)
+		objectsPath := filepath.Join(*moddir, objectsSubdir)
+
+		if err := os.RemoveAll(objectsPath); err != nil {
+			log.Fatalf("Error clearing directory %s: %v", objectsPath, err)
+		}
+
+		if err := os.MkdirAll(objectsPath, 0755); err != nil {
+			log.Fatalf("Error recreating directory %s: %v", objectsPath, err)
+		}
+
 		r := mod.Reverser{
 			ModSettingsWriter: ms,
 			LuaWriter:         lua,

--- a/main.go
+++ b/main.go
@@ -94,14 +94,8 @@ func main() {
 			objs = file.NewJSONOps(filepath.Dir(*objout))
 		} else {
 			// clear the objects directory to avoid orphaned files (by removing and recreating)
-			objectsPath := filepath.Join(*moddir, objectsSubdir)
-
-			if err := os.RemoveAll(objectsPath); err != nil {
-				log.Fatalf("Error clearing directory %s: %v", objectsPath, err)
-			}
-
-			if err := os.MkdirAll(objectsPath, 0755); err != nil {
-				log.Fatalf("Error recreating directory %s: %v", objectsPath, err)
+			if err := objdir.Clear(); err != nil {
+				log.Fatalf("Failed to clear objects directory before writing: %v", err)
 			}
 		}
 	

--- a/tests/fakefiles.go
+++ b/tests/fakefiles.go
@@ -116,6 +116,11 @@ func (f *FakeFiles) CreateDir(a, b string) (string, error) {
 	return b, nil
 }
 
+// Clear satisfies DirCreator
+func (f *FakeFiles) Clear() error {
+	return nil
+}
+
 // ListFilesAndFolders satisfies DirExplorer
 func (f *FakeFiles) ListFilesAndFolders(relpath string) ([]string, []string, error) {
 	// ignore non json files. i don't think they Matter


### PR DESCRIPTION
Right now, if you rename an object in TTS or change its GUID, you get both the old and the new file after decomposing.
This then blocks the build action, since the sanity check (same amount of files in the ContainedObjects_order key and in the actual folder) fails.

This PR clears the objects folder when reversing to make sure it is always a perfect mirror of the just unbundled savegame.