### PR TITLE
fix: revert #67 XmlUI injection that broke the reverse→generate round-trip

### DIFF
--- a/objects/objects.go
+++ b/objects/objects.go
@@ -67,13 +67,6 @@ func (o *objConfig) parseFromJSON(data map[string]interface{}) error {
 	if !ok {
 		return fmt.Errorf("object (%v) doesn't have a string GUID (%s)", dguid, o.data["GUID"])
 	}
-	_, ok = o.data["XmlUI_path"]
-	if !ok {
-		_, ok = o.data["XmlUI"]
-		if !ok {
-			o.data["XmlUI"] = ""
-		}
-	}
 	o.guid = guid
 	o.subObj = []*objConfig{}
 	o.subObjOrder = []string{}


### PR DESCRIPTION
## What

Reverts the 7-line change PR #67 added to `objConfig.parseFromJSON`, which injected `XmlUI: ""` into every object that lacked one.

## Why

Because `parseFromJSON` runs in **both** conversion directions, the injection gave any object with no `XmlUI` an `XmlUI: ""` on `reverse → generate`, so the output no longer matched the input. That broke the round-trip guarantee and failed the build across the `mod`, `objects`, and `tests` packages. `main` has been red since #67 merged.

The stated justification — "VSCode Plugin Compatibility" — does not hold. The referenced plugin (`rolandostar/tabletopsimulator-lua-vscode`) never reads TTSModManager's object JSON and has **no `XmlUI` key anywhere in its source or history**; it talks to TTS over TCP and manages its own `.lua`/`.xml` companion files. Injecting `XmlUI: ""` into these files has no effect on it. (The only defensible rationale for an always-present empty `XmlUI` is matching TTS's own save schema — a generate-only canonicalization concern, not a plugin one, and not what the injection did.)

## Verification

`go build ./...`, `go test ./...`, and `go vet ./...` all pass, under both Go 1.18 (CI's pinned version) and current Go, including `-shuffle=on`. No test changes were needed — removing the injection restores the pre-#67 behavior the tests already encode.

## Note

Filed as a standalone fix against `main` so it unblocks everyone, independent of the docs PR (#108) where this regression first surfaced.
