### PR TITLE
ci: run on merge_group so a merge queue can gate PRs

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  # Run in the merge queue so its checks can gate merges into main.
+  merge_group:
 
 jobs:
 


### PR DESCRIPTION
## What

Adds a `merge_group:` trigger to the Go workflow so it runs against the queued merge commit a merge queue produces.

## Why

A GitHub merge queue validates each PR by building a candidate merge commit and re-running the branch's required checks against it, via the `merge_group` event. If the workflow doesn't subscribe to that event, its checks never run in the queue — so a required "build" check can never be satisfied and queued PRs stall indefinitely.

This is the workflow half of enabling a merge queue on `main`; the branch-protection half (requiring the `build` check and turning the queue on) is configured in repo settings.

## Scope

CI trigger only — no build, test, or application changes.
