### PR TITLE
Normalize rotations below -360 in smoothRot

### DIFF
--- a/objects/numbersmoother.go
+++ b/objects/numbersmoother.go
@@ -139,7 +139,7 @@ func smoothPos(f float64) float64 {
 }
 
 func smoothRot(f float64) float64 {
-	r := math.Mod(roundFloat(f, 0)+360, 360)
+	r := math.Mod(math.Mod(roundFloat(f, 0), 360)+360, 360)
 	if r == float64(0) {
 		// for some reason -0.000001 is being returned as "-0"
 		return float64(0)

--- a/objects/numbersmoother_test.go
+++ b/objects/numbersmoother_test.go
@@ -54,6 +54,19 @@ func TestSmooth(t *testing.T) {
 			},
 		},
 		{
+			name: "Rotation beyond a full turn",
+			input: map[string]interface{}{
+				"rotX": float64(-400),
+				"rotY": float64(400),
+				"rotZ": float64(-40),
+			},
+			want: map[string]interface{}{
+				"rotX": float64(320),
+				"rotY": float64(40),
+				"rotZ": float64(320),
+			},
+		},
+		{
 			name: "Color",
 			input: map[string]interface{}{
 				"r": 0.42513,


### PR DESCRIPTION
`smoothRot` used `math.Mod(roundFloat(f,0)+360, 360)`. Because Go's `math.Mod` keeps the dividend's sign, this only normalized inputs above -360 (e.g. `-400` became `-40` instead of `320`).

This wraps the value with an inner `math.Mod` first, so any real rotation maps into `[0, 360)`. The existing `-0` guard is preserved. Added a table test case covering values beyond a full turn (`-400 -> 320`, `400 -> 40`, `-40 -> 320`).

`go build ./...`, `go test ./...`, and `go vet ./...` all pass.

Fixes #105