### PR TITLE
Remove dead code in objects package

### DIFF
--- a/objects/objects.go
+++ b/objects/objects.go
@@ -355,8 +355,6 @@ func (o *objConfig) tryGetNonEmptyStr(key string) (string, error) {
 type db struct {
 	root map[string]*objConfig
 
-	all map[string]*objConfig
-
 	j   file.JSONReader
 	dir file.DirExplorer
 }
@@ -394,17 +392,16 @@ func ParseAllObjectStates(l file.TextReader, x file.TextReader, j file.JSONReade
 	d := db{
 		j:    j,
 		dir:  dir,
-		all:  map[string]*objConfig{},
 		root: map[string]*objConfig{},
 	}
-	err := d.parseFromFolder("", nil)
+	err := d.parseFromFolder("")
 	if err != nil {
 		return []map[string]interface{}{}, fmt.Errorf("parseFolder(%s): %v", "<root>", err)
 	}
 	return d.print(l, x, order)
 }
 
-func (d *db) parseFromFolder(relpath string, parent *objConfig) error {
+func (d *db) parseFromFolder(relpath string) error {
 	filenames, _, err := d.dir.ListFilesAndFolders(relpath)
 	if err != nil {
 		return fmt.Errorf("ListFilesAndFolders(%s) : %v", relpath, err)
@@ -418,7 +415,7 @@ func (d *db) parseFromFolder(relpath string, parent *objConfig) error {
 		var o objConfig
 		err := o.parseFromFile(file, d.j)
 		if err != nil {
-			return fmt.Errorf("parseFromFile(%s, %v): %v", file, parent, err)
+			return fmt.Errorf("parseFromFile(%s): %v", file, err)
 		}
 		d.root[o.getAGoodFileName()] = &o
 	}


### PR DESCRIPTION
Removes two dead items in `objects/objects.go` with no behavior change:

1. `db.all` — struct field initialized in `ParseAllObjectStates` but never read or written after. Field and its initializer removed.
2. `parseFromFolder(relpath, parent *objConfig)` — the `parent` param was unused except in an error string, and its only call passed `nil`. Param removed, call site and error message updated.

`go build ./...`, `go vet ./...`, and `go test ./...` all pass.

Fixes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)