### PR TITLE
Fix three control-flow bugs in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -61,6 +61,14 @@ func main() {
 	objdir := file.NewDirOps(filepath.Join(*moddir, objectsSubdir))
 	rootops := file.NewJSONOps(*moddir)
 
+	// When generating a full mod with no explicit --modfile, default the output
+	// path to <moddir>/output.json. This must happen before basename/outputOps
+	// are derived, otherwise they are computed from an empty path (issue #93).
+	// Reverse mode uses --modfile as an input to read and must not be defaulted.
+	if !*rev && *modfile == "" {
+		*modfile = filepath.Join(*moddir, "output.json")
+	}
+
 	basename := filepath.Base(*modfile)
 	outputOps := file.NewJSONOps(filepath.Dir(*modfile))
 
@@ -92,16 +100,21 @@ func main() {
 		if *objin != "" {
 			*modfile = *objin
 			objs = file.NewJSONOps(filepath.Dir(*objout))
-		} else {
-			// clear the objects directory to avoid orphaned files (by removing and recreating)
-			if err := objdir.Clear(); err != nil {
-				log.Fatalf("Failed to clear objects directory before writing: %v", err)
-			}
 		}
-	
+
 		raw, err := prepForReverse(*moddir, *modfile)
 		if err != nil {
 			log.Fatalf("prepForReverse (%s) failed : %v", *modfile, err)
+		}
+
+		// Clear the objects directory to avoid orphaned files (by removing and
+		// recreating). This must run only after prepForReverse has successfully
+		// read and parsed the mod file, so a bad --modfile path can't wipe
+		// objects/ before failing (issue #90).
+		if *objin == "" {
+			if err := objdir.Clear(); err != nil {
+				log.Fatalf("Failed to clear objects directory before writing: %v", err)
+			}
 		}
 
 		r := mod.Reverser{
@@ -123,10 +136,6 @@ func main() {
 		}
 		return
 	}
-	if *modfile == "" {
-		*modfile = filepath.Join(*moddir, "output.json")
-	}
-
 	// setting this to empty instead of default return value (".") if not found
 	OnlyObjStates := filepath.Base(*objin)
 	if OnlyObjStates == "." {
@@ -146,8 +155,7 @@ func main() {
 	}
 	err := m.GenerateFromConfig()
 	if err != nil {
-		fmt.Printf("generateMod(<config>) : %v\n", err)
-		return
+		log.Fatalf("generateMod(<config>) : %v", err)
 	}
 	err = m.Print(basename)
 	if err != nil {


### PR DESCRIPTION
`main.go` is dependency-wiring only, but three control-flow bugs there cause data loss and wrong exit behavior. This fixes all three in one focused PR.

## Changes

### Fixes #90 — data loss on bad `--modfile` in reverse mode
`objdir.Clear()` (which deletes and recreates `objects/`) ran *before* `prepForReverse` read/validated `--modfile`, so a typo'd path wiped `objects/` and then failed. `Clear()` is now deferred until after `prepForReverse` successfully reads and parses the mod file. The existing safety check on `Clear()` is preserved.

### Fixes #92 — generate errors exit 0
On `GenerateFromConfig` error, main used `fmt.Printf` + `return` (exit 0), unlike every other path which uses `log.Fatalf`. Now uses `log.Fatalf` so failures exit non-zero.

### Fixes #93 — `--moddir=X` with no `--modfile` failed
`basename` and `outputOps` were derived from `*modfile` while it was still `""`, so generate with only `--moddir` failed (`open .: is a directory`). The `<moddir>/output.json` default is now applied to `*modfile` before those are derived. The default is guarded to generate mode, so reverse still treats `--modfile` as a required input.

## Verification
`go build ./...`, `go vet ./...`, and `go test ./...` all stay green.

Manual runs of the built binary against `tests/testdata/e2e/basic_objects.json`:

- **#93:** `--reverse --moddir=<tmp> --modfile=<json>` then `--moddir=<tmp>` (no `--modfile`) — generate now writes `<tmp>/output.json` (exit 0). `--objin`/`--objout` and saved-object paths are unaffected (their `basename`/`outputOps` come from `--objout` and override the default).
- **#90:** `--reverse --moddir=<tmp> --modfile=<nonexistent>` against a moddir containing `objects/` — `objects/` is **not** deleted and the process exits non-zero (`prepForReverse ... failed`).