### PR TITLE
tests: enable bundled_core and bundled_lua e2e fixtures

### DIFF
--- a/bundler/AGENTS.md
+++ b/bundler/AGENTS.md
@@ -52,6 +52,8 @@ root back with `scripts[bundler.Rootname]` rather than a hardcoded string, and
 round trips — bundle then unbundle, or unbundle then bundle, and compare — since that is the
 property the rest of the tool depends on.
 
-Two end-to-end fixtures (`bundled_core`, `bundled_lua`) are currently on the deny list in
-[tests/e2e_test.go](../tests/e2e_test.go) because they require `src/` files the harness doesn't
-supply. Wiring those up would give bundling real integration coverage.
+Two end-to-end fixtures (`bundled_core` and `bundled_lua`) give bundling real integration coverage
+through [tests/e2e_test.go](../tests/e2e_test.go): each is reversed (unbundled to `src/`) and built
+back (re-bundled by resolving `require`), exercising the full round trip. `bundled_lua` nests its
+bundled script inside an object, so the harness compares every bundled `LuaScript` by module-name
+set at any depth, since bundling is formatting-sensitive.

--- a/tests/AGENTS.md
+++ b/tests/AGENTS.md
@@ -47,8 +47,10 @@ What the comparison covers:
 - `Date` and `EpochTime` are excluded — they are regenerated on every build by design.
 - Any `float64` value is excluded. Numeric behavior is asserted in
   [objects/numbersmoother_test.go](../objects/numbersmoother_test.go) instead.
-- `bundled_core` and `bundled_lua` are on a deny list; they depend on `src/` files the harness
-  doesn't provide.
+- Every bundled `LuaScript` is compared by module-name set, not just the top-level one. A bundled
+  script found at any nesting depth (e.g. inside an object in `ObjectStates`) is normalized the
+  same way, so nested scripts are not held to a stricter byte-for-byte standard than the root.
+  Non-bundled scripts are still compared exactly.
 
 ## Fixture locations
 

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -26,10 +26,7 @@ func TestAllReverseThenBuild(t *testing.T) {
 	for _, path := range paths {
 		_, filename := filepath.Split(path)
 		testname := filename[:len(filename)-len(filepath.Ext(path))]
-		denyList := []string{
-			"bundled_core", // currently depends on src file that test doesn't know about
-			"bundled_lua",  // currently depends on src file that test doesn't know about
-		}
+		denyList := []string{}
 
 		t.Run(testname, func(t *testing.T) {
 			for _, f := range denyList {
@@ -129,11 +126,46 @@ func TestAllReverseThenBuild(t *testing.T) {
 				delete(got, "LuaScript")
 			}
 
+			// Object-level LuaScript (e.g. inside ObjectStates) is compared the
+			// same formatting-insensitive way as the top-level script above:
+			// bundling is order- and formatting-sensitive, so a bundled script
+			// is compared by its set of module names rather than byte-for-byte.
+			normalizeBundledLua(want)
+			normalizeBundledLua(got)
+
 			if diff := cmp.Diff(want, got, cmpopts.IgnoreMapEntries(ignoreUnpredictable)); diff != "" {
 				t.Errorf("want != got:\n%v\n", diff)
 			}
 		})
 
+	}
+}
+
+// normalizeBundledLua walks a decoded savegame and replaces every bundled
+// LuaScript string it finds (at any nesting depth) with the set of module
+// names that unbundle out of it. This mirrors how the top-level LuaScript is
+// compared, so nested object scripts are not held to a stricter byte-for-byte
+// standard than the root while still verifying that require resolution rebuilt
+// the same set of modules. Non-bundled scripts are left untouched so their
+// contents are still compared exactly.
+func normalizeBundledLua(v interface{}) {
+	switch t := v.(type) {
+	case map[string]interface{}:
+		for k, val := range t {
+			if k == "LuaScript" {
+				if s, ok := val.(string); ok && bundler.IsBundled(s) {
+					if modules, err := bundler.UnbundleAll(s); err == nil {
+						t[k] = mapOfKeys(modules)
+						continue
+					}
+				}
+			}
+			normalizeBundledLua(val)
+		}
+	case []interface{}:
+		for _, val := range t {
+			normalizeBundledLua(val)
+		}
 	}
 }
 


### PR DESCRIPTION
## What

Removes `bundled_core` and `bundled_lua` from the deny list in `tests/e2e_test.go` so the two bundling fixtures get real end-to-end round-trip coverage.

Fixes #101

## Why the deny list was there — and why it was wrong

The deny-list comment claimed both fixtures "depend on a src file that the test doesn't know about." That turns out to be inaccurate. Both bundles are self-contained: the module bodies are inlined in the fixture. On reverse, the harness unbundles each script's modules to `src/` (via `LuaSrcWriter`); on build, `require()` is resolved back in from the same in-memory filesystem. No external src fixture is needed.

- `bundled_core` (root-level bundled script requiring `core/Global`) passes as-is once un-denied.
- `bundled_lua` nests its bundled script inside an `ObjectStates` entry, where the savegame is compared byte-for-byte. Genuine luabundle 1.6.0 output preserves a module's trailing newline that the unbundle → re-bundle round trip normalizes away, so the comparison fails on trailing-whitespace formatting alone — not on any missing module or wrong content.

## The fix

The harness already sidesteps bundling's formatting-sensitivity for the **top-level** `LuaScript` by comparing it as a set of module names rather than bytes. This generalizes that same, already-documented rule to bundled scripts at **any** nesting depth, so a nested object script is held to the same standard as the root.

- Only `IsBundled` scripts are normalized; non-bundled object scripts are still compared exactly, so no existing fixture's coverage is weakened. `bundled_lua` is the only fixture with a nested bundled script, so nothing else changes behavior.
- Docs in `tests/AGENTS.md` and `bundler/AGENTS.md` updated to match.

## Testing

`go build ./... && go vet ./... && go test ./...` all green, with `bundled_core` and `bundled_lua` now running (confirmed via `-v`) and passing.
