### PR TITLE
fix: handler_test.go 3-value unbundle signature (unbreak main after #116+#118)

### DIFF
--- a/handler/handler_test.go
+++ b/handler/handler_test.go
@@ -132,7 +132,7 @@ func bundledWithModule(t *testing.T, h *Handler, name, ext string) (string, stri
 		t.Fatalf("bundling fixture: %v", err)
 	}
 	// sanity: it must actually unbundle into more than just the root
-	all, err := h.unbundle(bundled)
+	all, _, err := h.unbundle(bundled)
 	if err != nil {
 		t.Fatalf("unbundling fixture: %v", err)
 	}


### PR DESCRIPTION
#116 and #118 merged clean individually but are incompatible together — #116's handler test used the old 2-value `unbundle`, #118 changed it to 3. This discards the new root-name return in the test so `handler` compiles again. Build/vet/test all green.