### PR TITLE
fix: e2e_test.go 3-value UnbundleAll (unbreak main after #118+#119)

### DIFF
--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -154,7 +154,7 @@ func normalizeBundledLua(v interface{}) {
 		for k, val := range t {
 			if k == "LuaScript" {
 				if s, ok := val.(string); ok && bundler.IsBundled(s) {
-					if modules, err := bundler.UnbundleAll(s); err == nil {
+					if modules, _, err := bundler.UnbundleAll(s); err == nil {
 						t[k] = mapOfKeys(modules)
 						continue
 					}


### PR DESCRIPTION
#119's new normalizeBundledLua used the old 2-value UnbundleAll; #118 made it 3-value. They merged textually without a conflict but don't compile together. One-line fix at the call site. Full build/vet/test green.