### PR TITLE
ci: enforce gofmt/vet/race; format existing files

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,8 +23,18 @@ jobs:
       with:
         go-version: 1.18
 
+    - name: Format check
+      run: |
+        unformatted=$(gofmt -l .)
+        if [ -n "$unformatted" ]; then
+          echo "These files are not gofmt-clean:"; echo "$unformatted"; exit 1
+        fi
+
+    - name: Vet
+      run: go vet ./...
+
     - name: Build
       run: go build -v ./...
 
     - name: Test
-      run: go test -v ./...
+      run: go test -race -v ./...

--- a/file/textops_test.go
+++ b/file/textops_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-
 )
 
 type fakeFiles struct {

--- a/mod/generate.go
+++ b/mod/generate.go
@@ -29,15 +29,15 @@ var (
 // Mod is used as the accurate representation of what gets printed when
 // module creation is done
 type Mod struct {
-	Data          types.J
-	RootRead      file.JSONReader
-	RootWrite     file.JSONWriter
-	Lua           file.TextReader
-	XML           file.TextReader
-	Modsettings   file.JSONReader
-	Objs          file.JSONReader
-	Objdirs       file.DirExplorer
-	SavedObj      bool
+	Data        types.J
+	RootRead    file.JSONReader
+	RootWrite   file.JSONWriter
+	Lua         file.TextReader
+	XML         file.TextReader
+	Modsettings file.JSONReader
+	Objs        file.JSONReader
+	Objdirs     file.DirExplorer
+	SavedObj    bool
 
 	// If not-empty: this holds the root filename for the object state json object
 	OnlyObjStates string

--- a/mod/generate_test.go
+++ b/mod/generate_test.go
@@ -200,14 +200,14 @@ func TestGenerate(t *testing.T) {
 		{
 			name: "Saved Object (Simple)",
 			inputObjs: map[string]types.J{
-        "test123.json": map[string]interface{}{
+				"test123.json": map[string]interface{}{
 					"GUID":        "test123",
 					"Description": "A test object",
-        },
-    	},
+				},
+			},
 			flags: map[string]interface{}{
 				"OnlyObjStates": true,
-				"SavedObj": true,
+				"SavedObj":      true,
 			},
 			want: map[string]interface{}{
 				"SaveName":       "",

--- a/mod/reverse.go
+++ b/mod/reverse.go
@@ -21,7 +21,7 @@ type Reverser struct {
 	RootWrite         file.JSONWriter
 
 	// If not empty: holds the entire filename (C:...) of the json to read
-	OnlyObjState      string
+	OnlyObjState string
 }
 
 func (r *Reverser) writeOnlyObjStates(raw map[string]interface{}) error {
@@ -68,7 +68,7 @@ func (r *Reverser) Write(raw map[string]interface{}) error {
 		}
 
 		createdFile := strKey + ext
-		
+
 		var jsonInterface map[string]interface{}
 		err := json.Unmarshal([]byte(strVal), &jsonInterface)
 		if err == nil {

--- a/objects/objects_test.go
+++ b/objects/objects_test.go
@@ -323,7 +323,7 @@ func TestObjPrintingToFile(t *testing.T) {
 				content: types.J{
 					"acknowledgedUpgradeVersions": []any{},
 					"optionPanel": map[string]any{
-						"cardLanguage": string("en"),
+						"cardLanguage":        string("en"),
 						"changePlayAreaImage": bool(false),
 						"playAreaConnectionColor": map[string]any{
 							"a": float64(1),
@@ -406,7 +406,7 @@ func TestName(t *testing.T) {
 			guid: "010509",
 			want: "OccultInvocation!!!!.010509",
 		}, {
-				data: types.J{
+			data: types.J{
 				"Nickname": "Verschwörung der Äxte!",
 				"Name":     "Card",
 			},


### PR DESCRIPTION
The Go workflow only ran build+test. This adds a **gofmt check**, **go vet**, and **-race** to the test run so formatting problems, vet issues, and data races are caught in CI. Also gofmt's five files that weren't format-clean so the new check passes. All four checks verified green locally (incl. `go test -race ./...`).